### PR TITLE
Fix usageMode check and version check

### DIFF
--- a/src/main/java/me/Qball/Wild/Commands/CmdWild.java
+++ b/src/main/java/me/Qball/Wild/Commands/CmdWild.java
@@ -22,7 +22,7 @@ public class CmdWild implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String lable, String[] args) {
-        if ((wild.usageMode != UsageMode.COMMAND_ONLY || wild.usageMode != UsageMode.BOTH)) {
+        if ((wild.usageMode != UsageMode.COMMAND_ONLY && wild.usageMode != UsageMode.BOTH)) {
             sender.sendMessage(wild.getConfig().getString("UsageDisabled"));
             return true;
         }

--- a/src/main/java/me/Qball/Wild/Wild.java
+++ b/src/main/java/me/Qball/Wild/Wild.java
@@ -61,7 +61,7 @@ public class Wild extends JavaPlugin{
     public void onEnable() {
         String[] tmp = Bukkit.getVersion().split("MC: ");
         String version = tmp[tmp.length - 1].substring(0, 4);
-        thirteen = version.contains("1.13");
+        thirteen = version.contains("1.13") || version.contains("1.14");
         instance = this;
         this.getCommand("wildtp").setExecutor(new CmdWildTp(this));
         this.getCommand("wild").setExecutor(new CmdWild(this));


### PR DESCRIPTION
Hey, I found two small things from building the latest master for my server:

- The new `usageMode` check should be `&&`, like the sign one https://github.com/Qballl/WildernessTp/blob/abf9c87b5eae029c583004c200eb3962fdda4fbc/src/main/java/me/Qball/Wild/Listeners/SignClick.java#L29
- Have the `thirteen` bool for nether vs hell be true for `1.14` too.